### PR TITLE
Add support for client-side scheduling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
           pip install hatch
       - name: Pull images
         run: |
-          docker pull mrcide/privateer-server:latest
-          docker pull mrcide/privateer-client:latest
+          docker pull mrcide/privateer-server:reside-352
+          docker pull mrcide/privateer-client:reside-352
       - name: Test
         run: |
           hatch run cov-ci

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -6,5 +6,7 @@ RUN apt-get update && \
         rsync && \
         mkdir -p /root/.ssh
 
+RUN curl -L -o /usr/bin/yacron https://github.com/gjcarneiro/yacron/releases/download/0.19.0/yacron-0.19.0-x86_64-unknown-linux-gnu && chmod 755 /usr/bin/yacron
+
 COPY ssh_config /etc/ssh/ssh_config
 VOLUME /privateer/keys

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -2,11 +2,14 @@ FROM ubuntu
 
 RUN apt-get update && \
         apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
         openssh-client \
         rsync && \
         mkdir -p /root/.ssh
 
-RUN curl -L -o /usr/bin/yacron https://github.com/gjcarneiro/yacron/releases/download/0.19.0/yacron-0.19.0-x86_64-unknown-linux-gnu && chmod 755 /usr/bin/yacron
+RUN curl -L -o /usr/bin/yacron https://github.com/gjcarneiro/yacron/releases/download/0.19.0/yacron-0.19.0-x86_64-unknown-linux-gnu && \
+        chmod 755 /usr/bin/yacron
 
 COPY ssh_config /etc/ssh/ssh_config
 VOLUME /privateer/keys

--- a/example/montagu.json
+++ b/example/montagu.json
@@ -14,7 +14,17 @@
     "clients": [
         {
             "name": "production",
-            "backup": ["montagu_orderly_volume"]
+            "backup": ["montagu_orderly_volume"],
+            "schedule": {
+                "port": 8080,
+                "jobs": [
+                    {
+                        "server": "annex2",
+                        "volume": "montagu_orderly_volume",
+                        "schedule": "@daily"
+                    }
+                ]
+            }
         },
         {
             "name": "production2",

--- a/example/montagu.json
+++ b/example/montagu.json
@@ -18,7 +18,18 @@
         },
         {
             "name": "production2",
-            "backup": ["montagu_orderly_volume"]
+            "backup": ["montagu_orderly_volume"],
+            "schedule": {
+                "container": "privateer_cron",
+                "volume": "privateer_schedule",
+                "jobs": [
+                    {
+                        "server": "annex2",
+                        "volume": "montagu_orderly_volume",
+                        "schedule": "@daily"
+                    }
+                ]
+            }
         },
         {
             "name": "science"

--- a/example/montagu.json
+++ b/example/montagu.json
@@ -20,8 +20,7 @@
             "name": "production2",
             "backup": ["montagu_orderly_volume"],
             "schedule": {
-                "container": "privateer_cron",
-                "volume": "privateer_schedule",
+                "port": 8080,
                 "jobs": [
                     {
                         "server": "annex2",

--- a/example/schedule.json
+++ b/example/schedule.json
@@ -1,0 +1,43 @@
+{
+    "servers": [
+        {
+            "name": "alice",
+            "hostname": "alice.example.com",
+            "port": 10022
+        }
+    ],
+    "clients": [
+        {
+            "name": "bob",
+            "backup": ["data1", "data2"],
+            "restore": ["data1", "data2"],
+            "schedule": {
+                "port": 8080,
+                "jobs": [
+                    {
+                        "server": "alice",
+                        "volume": "data1",
+                        "schedule": "@daily"
+                    },
+                    {
+                        "server": "alice",
+                        "volume": "data2",
+                        "schedule": "@weekly"
+                    }
+                ]
+            }
+        }
+    ],
+    "volumes": [
+        {
+            "name": "data1"
+        },
+        {
+            "name": "data2"
+        }
+    ],
+    "vault": {
+        "url": "http://localhost:8200",
+        "prefix": "/secret/privateer"
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,9 @@ dependencies = [
     "docker",
     "docopt",
     "hvac",
-    "pydantic"
+    "pydantic",
+    "tzlocal",
+    "yacron"
 ]
 
 [project.urls]

--- a/src/privateer2/__about__.py
+++ b/src/privateer2/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Rich FitzJohn <r.fitzjohn@imperial.ac.uk>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/src/privateer2/backup.py
+++ b/src/privateer2/backup.py
@@ -8,7 +8,7 @@ def backup_command(name, volume, server):
         "rsync",
         "-av",
         "--delete",
-        f"/privateer/{volume}",
+        f"/privateer/volumes/{volume}",
         f"{server}:/privateer/volumes/{name}",
     ]
 
@@ -18,7 +18,7 @@ def backup(cfg, name, volume, *, server=None, dry_run=False):
     server = match_value(server, cfg.list_servers(), "server")
     volume = match_value(volume, machine.backup, "volume")
     image = f"mrcide/privateer-client:{cfg.tag}"
-    src = f"/privateer/{volume}"
+    src = f"/privateer/volumes/{volume}"
     mounts = [
         docker.types.Mount(
             "/privateer/keys", machine.key_volume, type="volume", read_only=True

--- a/src/privateer2/cli.py
+++ b/src/privateer2/cli.py
@@ -4,9 +4,10 @@
   privateer2 [options] keygen (<name> | --all)
   privateer2 [options] configure <name>
   privateer2 [options] check [--connection]
-  privateer2 [options] server (start | stop | status)
   privateer2 [options] backup <volume> [--server=NAME]
   privateer2 [options] restore <volume> [--server=NAME] [--source=NAME]
+  privateer2 [options] server (start | stop | status)
+  privateer2 [options] schedule (start | stop | status)
 
 Options:
   --path=PATH  The path to the configuration, or directory with privateer.json
@@ -17,6 +18,10 @@ Commentary:
   In all the above '--as' (or <name>) refers to the name of the client
   or server being acted on; the machine we are generating keys for,
   configuring, checking, serving, backing up from or restoring to.
+
+  The server and schedule commands start background containers that
+  run forever (with the 'start' option). Check in on them with
+  'status' or stop them with 'stop'.
 """
 
 import os
@@ -31,6 +36,7 @@ from privateer2.config import read_config
 from privateer2.configure import configure
 from privateer2.keys import keygen, keygen_all
 from privateer2.restore import restore
+from privateer2.schedule import schedule_start, schedule_status, schedule_stop
 from privateer2.server import server_start, server_status, server_stop
 
 
@@ -134,13 +140,6 @@ def _parse_opts(opts):
         if opts["check"]:
             connection = opts["--connection"]
             return Call(check, cfg=cfg, name=name, connection=connection)
-        elif opts["server"]:
-            if opts["start"]:
-                return Call(server_start, cfg=cfg, name=name, dry_run=dry_run)
-            elif opts["stop"]:
-                return Call(server_stop, cfg=cfg, name=name)
-            else:
-                return Call(server_status, cfg=cfg, name=name)
         elif opts["backup"]:
             return Call(
                 backup,
@@ -160,6 +159,20 @@ def _parse_opts(opts):
                 source=opts["--source"],
                 dry_run=dry_run,
             )
+        elif opts["server"]:
+            if opts["start"]:
+                return Call(server_start, cfg=cfg, name=name, dry_run=dry_run)
+            elif opts["stop"]:
+                return Call(server_stop, cfg=cfg, name=name)
+            else:
+                return Call(server_status, cfg=cfg, name=name)
+        elif opts["schedule"]:
+            if opts["start"]:
+                return Call(schedule_start, cfg=cfg, name=name, dry_run=dry_run)
+            elif opts["stop"]:
+                return Call(schedule_stop, cfg=cfg, name=name)
+            else:
+                return Call(schedule_status, cfg=cfg, name=name)
         else:
             msg = "Invalid cli call -- privateer bug"
             raise Exception(msg)

--- a/src/privateer2/config.py
+++ b/src/privateer2/config.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -10,6 +10,18 @@ from privateer2.vault import vault_client
 def read_config(path):
     with open(path) as f:
         return Config(**json.loads(f.read().strip()))
+
+
+class ScheduleJob(BaseModel):
+    server: str
+    volume: str
+    schedule: str
+
+
+class Schedule(BaseModel):
+    port: Optional[int]
+    container: str = "privateer_scheduler"
+    jobs: List[ScheduleJob]
 
 
 class Server(BaseModel):
@@ -25,6 +37,7 @@ class Client(BaseModel):
     name: str
     backup: List[str] = []
     key_volume: str = "privateer_keys"
+    schedule: Optional[Schedule] = None
 
 
 class Volume(BaseModel):
@@ -102,6 +115,20 @@ def _check_config(cfg):
             if v in vols_local:
                 msg = f"Client '{cl.name}' backs up local volume '{v}'"
                 raise Exception(msg)
+        if cl.schedule:
+            for j in cl.schedule.jobs:
+                if j.server not in servers:
+                    msg = (
+                        f"Client '{cl.name}' scheduling backup to "
+                        f"unknown server '{j.server}'"
+                    )
+                    raise Exception(msg)
+                if j.volume not in cl.backup:
+                    msg = (
+                        f"Client '{cl.name}' scheduling backup of "
+                        f"volume '{j.volume}', which it does not back up"
+                    )
+                    raise Exception(msg)
     if cfg.vault.prefix.startswith("/secret"):
         cfg.vault.prefix = cfg.vault.prefix[7:]
 

--- a/src/privateer2/config.py
+++ b/src/privateer2/config.py
@@ -19,7 +19,7 @@ class ScheduleJob(BaseModel):
 
 
 class Schedule(BaseModel):
-    port: Optional[int]
+    port: Optional[int] = None
     container: str = "privateer_scheduler"
     jobs: List[ScheduleJob]
 

--- a/src/privateer2/config.py
+++ b/src/privateer2/config.py
@@ -58,7 +58,7 @@ class Config(BaseModel):
     clients: List[Client]
     volumes: List[Volume]
     vault: Vault
-    tag: str = "latest"
+    tag: str = "reside-352"
 
     def model_post_init(self, __context):
         _check_config(self)

--- a/src/privateer2/configure.py
+++ b/src/privateer2/configure.py
@@ -1,36 +1,41 @@
 import docker
 from privateer2.keys import keys_data
 from privateer2.util import string_to_volume
+from privateer2.yacron import generate_yacron_yaml
 
 
 def configure(cfg, name):
     cl = docker.from_env()
-    data = keys_data(cfg, name)
+    keys = keys_data(cfg, name)
+    schedule = generate_yacron_yaml(cfg, name)
     vol = cfg.machine_config(name).key_volume
     cl.volumes.create(vol)
     print(f"Copying keypair for '{name}' to volume '{vol}'")
     string_to_volume(
-        data["public"], vol, "id_rsa.pub", uid=0, gid=0, mode=0o644
+        keys["public"], vol, "id_rsa.pub", uid=0, gid=0, mode=0o644
     )
-    string_to_volume(data["private"], vol, "id_rsa", uid=0, gid=0, mode=0o600)
-    if data["authorized_keys"]:
+    string_to_volume(keys["private"], vol, "id_rsa", uid=0, gid=0, mode=0o600)
+    if keys["authorized_keys"]:
         print("Authorising public keys")
         string_to_volume(
-            data["authorized_keys"],
+            keys["authorized_keys"],
             vol,
             "authorized_keys",
             uid=0,
             gid=0,
             mode=0o600,
         )
-    if data["known_hosts"]:
+    if keys["known_hosts"]:
         print("Recognising servers")
         string_to_volume(
-            data["known_hosts"], vol, "known_hosts", uid=0, gid=0, mode=0o600
+            keys["known_hosts"], vol, "known_hosts", uid=0, gid=0, mode=0o600
         )
-    if data["config"]:
+    if keys["config"]:
         print("Adding ssh config")
         string_to_volume(
-            data["config"], vol, "config", uid=0, gid=0, mode=0o600
+            keys["config"], vol, "config", uid=0, gid=0, mode=0o600
         )
+    if schedule:
+        print("Adding yacron schedule")
+        string_to_volume(schedule, vol, "yacron.yml", uid=0, gid=0)
     string_to_volume(name, vol, "name", uid=0, gid=0)

--- a/src/privateer2/restore.py
+++ b/src/privateer2/restore.py
@@ -10,7 +10,7 @@ def restore(cfg, name, volume, *, server=None, source=None, dry_run=False):
     volume = match_value(volume, cfg.list_volumes(), "volume")
     source = find_source(cfg, volume, source)
     image = f"mrcide/privateer-client:{cfg.tag}"
-    dest_mount = f"/privateer/{volume}"
+    dest_mount = f"/privateer/volumes/{volume}"
     mounts = [
         docker.types.Mount(
             "/privateer/keys", machine.key_volume, type="volume", read_only=True

--- a/src/privateer2/schedule.py
+++ b/src/privateer2/schedule.py
@@ -1,5 +1,5 @@
 import docker
-from privateer2.keys import check
+from privateer2.check import check
 from privateer2.service import service_start, service_status, service_stop
 from privateer2.util import unique
 

--- a/src/privateer2/schedule.py
+++ b/src/privateer2/schedule.py
@@ -1,0 +1,43 @@
+import docker
+from privateer2.keys import check
+from privateer2.service import service_start, service_status, service_stop
+from privateer2.util import unique
+
+
+def schedule_start(cfg, name, *, dry_run=False):
+    machine = check(cfg, name, quiet=True)
+    if not machine.schedule:
+        msg = f"A schedule is not defined in the configuration for '{name}'"
+        raise Exception(msg)
+
+    mounts = [
+        docker.types.Mount(
+            "/privateer/keys", machine.key_volume, type="volume", read_only=True
+        ),
+    ]
+    for v in unique([job.volume for job in machine.schedule.jobs]):
+        mounts.append(
+            docker.types.Mount(
+                f"/privateer/volumes/{v}", v, type="volume", read_only=True
+            )
+        )
+    port = machine.schedule.port
+    service_start(
+        name,
+        machine.schedule.container,
+        image=f"mrcide/privateer-client:{cfg.tag}",
+        mounts=mounts,
+        ports={f"{port}/tcp": port} if port else None,
+        command=["yacron", "-c", "/privateer/keys/yacron.yml"],
+        dry_run=dry_run,
+    )
+
+
+def schedule_stop(cfg, name):
+    machine = check(cfg, name, quiet=True)
+    service_stop(name, machine.schedule.container)
+
+
+def schedule_status(cfg, name):
+    machine = check(cfg, name, quiet=False)
+    service_status(machine.schedule.container)

--- a/src/privateer2/service.py
+++ b/src/privateer2/service.py
@@ -37,8 +37,7 @@ def service_start(
         cmd = service_command(
             image, container_name, mounts=mounts, ports=ports, command=command
         )
-        # TODO: fix this name
-        print("Command to manually launch server:")
+        print("Command to manually launch service container:")
         print()
         print(f"  {' '.join(cmd)}")
         print()

--- a/src/privateer2/service.py
+++ b/src/privateer2/service.py
@@ -37,6 +37,7 @@ def service_start(
         cmd = service_command(
             image, container_name, mounts=mounts, ports=ports, command=command
         )
+        # TODO: fix this name
         print("Command to manually launch server:")
         print()
         print(f"  {' '.join(cmd)}")

--- a/src/privateer2/util.py
+++ b/src/privateer2/util.py
@@ -9,7 +9,19 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
+import tzlocal
+
 import docker
+
+
+def unique(x):
+    seen = set()
+    ret = []
+    for el in x:
+        if el not in seen:
+            ret.append(el)
+            seen.add(el)
+    return ret
 
 
 def string_to_volume(text, volume, path, **kwargs):
@@ -262,3 +274,7 @@ def transient_working_directory(path):
         yield
     finally:
         os.chdir(origin)
+
+
+def current_timezone_name():
+    return str(tzlocal.get_localzone())

--- a/src/privateer2/yacron.py
+++ b/src/privateer2/yacron.py
@@ -9,9 +9,6 @@ from privateer2.util import current_timezone_name
 
 def generate_yacron_yaml(cfg, name):
     machine = cfg.machine_config(name)
-    if not machine.schedule:
-        msg = "{type(machine).__name__} '{name}' does not have a schedule"
-        raise Exception(msg)
     ret = ["defaults:", f'  timezone: "{current_timezone_name()}"']
 
     if machine.schedule.port:
@@ -26,16 +23,18 @@ def generate_yacron_yaml(cfg, name):
         ret.append(f'  - name: "{job_name}"')
         ret.append(f'    command: "{cmd}"')
         ret.append(f'    schedule: "{job.schedule}"')
+
+    _validate_yacron_yaml(ret)
     return ret
 
 
-def validate_yacron_yaml(text):
-    if isinstance(text, list):
-        text = "".join(f"{x}\n" for x in text)
+def _validate_yacron_yaml(text):
+    text = "".join(f"{x}\n" for x in text)
     try:
         fd, tmp = tempfile.mkstemp(text=True)
         with os.fdopen(fd, "w") as f:
             f.write(text)
         yacron.config.parse_config(tmp)
+        return True
     finally:
         os.remove(tmp)

--- a/src/privateer2/yacron.py
+++ b/src/privateer2/yacron.py
@@ -4,11 +4,15 @@ import tempfile
 import yacron.config
 
 from privateer2.backup import backup_command
+from privateer2.config import Client
 from privateer2.util import current_timezone_name
 
 
 def generate_yacron_yaml(cfg, name):
     machine = cfg.machine_config(name)
+    if not isinstance(cfg, Client) or not machine.schedule:
+        return None
+
     ret = ["defaults:", f'  timezone: "{current_timezone_name()}"']
 
     if machine.schedule.port:

--- a/src/privateer2/yacron.py
+++ b/src/privateer2/yacron.py
@@ -10,7 +10,7 @@ from privateer2.util import current_timezone_name
 
 def generate_yacron_yaml(cfg, name):
     machine = cfg.machine_config(name)
-    if not isinstance(cfg, Client) or not machine.schedule:
+    if not isinstance(machine, Client) or not machine.schedule:
         return None
 
     ret = ["defaults:", f'  timezone: "{current_timezone_name()}"']

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -27,7 +27,8 @@ def test_can_print_instructions_to_run_backup(capsys, managed_docker):
             "  docker run --rm "
             f"-v {vol}:/privateer/keys:ro -v data:/privateer/volumes/data:ro "
             f"mrcide/privateer-client:{cfg.tag} "
-            "rsync -av --delete /privateer/volumes/data alice:/privateer/volumes/bob"
+            "rsync -av --delete /privateer/volumes/data "
+            "alice:/privateer/volumes/bob"
         )
         assert cmd in lines
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -25,9 +25,9 @@ def test_can_print_instructions_to_run_backup(capsys, managed_docker):
         assert "Command to manually run backup:" in lines
         cmd = (
             "  docker run --rm "
-            f"-v {vol}:/privateer/keys:ro -v data:/privateer/data:ro "
+            f"-v {vol}:/privateer/keys:ro -v data:/privateer/volumes/data:ro "
             f"mrcide/privateer-client:{cfg.tag} "
-            "rsync -av --delete /privateer/data alice:/privateer/volumes/bob"
+            "rsync -av --delete /privateer/volumes/data alice:/privateer/volumes/bob"
         )
         assert cmd in lines
 
@@ -51,7 +51,7 @@ def test_can_run_backup(monkeypatch, managed_docker):
             "rsync",
             "-av",
             "--delete",
-            "/privateer/data",
+            "/privateer/volumes/data",
             "alice:/privateer/volumes/bob",
         ]
         mounts = [
@@ -59,7 +59,7 @@ def test_can_run_backup(monkeypatch, managed_docker):
                 "/privateer/keys", vol, type="volume", read_only=True
             ),
             docker.types.Mount(
-                "/privateer/data", "data", type="volume", read_only=True
+                "/privateer/volumes/data", "data", type="volume", read_only=True
             ),
         ]
         assert mock_run.call_count == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,3 +293,43 @@ def test_clean_path(tmp_path):
     assert _path_config("example/simple.json") == "example/simple.json"
     with transient_working_directory(str(tmp_path)):
         assert _path_config(None) == "privateer.json"
+
+
+def test_can_parse_schedule_start(tmp_path):
+    shutil.copy("example/schedule.json", tmp_path / "privateer.json")
+    with open(tmp_path / ".privateer_identity", "w") as f:
+        f.write("bob\n")
+    with transient_working_directory(tmp_path):
+        res = _parse_argv(["schedule", "start"])
+    assert res.target == privateer2.cli.schedule_start
+    assert res.kwargs == {
+        "cfg": read_config("example/schedule.json"),
+        "name": "bob",
+        "dry_run": False,
+    }
+
+
+def test_can_parse_schedule_status(tmp_path):
+    shutil.copy("example/schedule.json", tmp_path / "privateer.json")
+    with open(tmp_path / ".privateer_identity", "w") as f:
+        f.write("bob\n")
+    with transient_working_directory(tmp_path):
+        res = _parse_argv(["schedule", "status"])
+    assert res.target == privateer2.cli.schedule_status
+    assert res.kwargs == {
+        "cfg": read_config("example/schedule.json"),
+        "name": "bob",
+    }
+
+
+def test_can_parse_schedule_stop(tmp_path):
+    shutil.copy("example/schedule.json", tmp_path / "privateer.json")
+    with open(tmp_path / ".privateer_identity", "w") as f:
+        f.write("bob\n")
+    with transient_working_directory(tmp_path):
+        res = _parse_argv(["schedule", "stop"])
+    assert res.target == privateer2.cli.schedule_stop
+    assert res.kwargs == {
+        "cfg": read_config("example/schedule.json"),
+        "name": "bob",
+    }

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -65,3 +65,36 @@ def test_can_unpack_keys_for_client(managed_docker):
         cfg.servers[0].key_volume = vol
         with pytest.raises(Exception, match=msg):
             check(cfg, "alice")
+
+
+def test_can_write_schedule_for_client(managed_docker):
+    with vault_dev.Server(export_token=True) as server:
+        cfg = read_config("example/schedule.json")
+        cfg.vault.url = server.url()
+        vol = managed_docker("volume")
+        cfg.clients[0].key_volume = vol
+        keygen_all(cfg)
+        configure(cfg, "bob")
+        client = docker.from_env()
+        mounts = [docker.types.Mount("/keys", vol, type="volume")]
+        name = managed_docker("container")
+        res = client.containers.run(
+            "alpine",
+            mounts=mounts,
+            command=["ls", "/keys"],
+            name=name,
+        )
+        assert set(res.decode("UTF-8").strip().split("\n")) == {
+            "known_hosts",
+            "id_rsa",
+            "id_rsa.pub",
+            "name",
+            "config",
+            "yacron.yml"
+        }
+        # assert string_from_volume(vol, "name") == "bob"
+        # assert check(cfg, "bob").key_volume == vol
+        # msg = "Configuration is for 'bob', not 'alice'"
+        # cfg.servers[0].key_volume = vol
+        # with pytest.raises(Exception, match=msg):
+        #     check(cfg, "alice")

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -7,6 +7,7 @@ from privateer2.config import read_config
 from privateer2.configure import configure
 from privateer2.keys import keygen_all
 from privateer2.util import string_from_volume
+from privateer2.yacron import generate_yacron_yaml
 
 
 def test_can_unpack_keys_for_server(managed_docker):
@@ -92,9 +93,6 @@ def test_can_write_schedule_for_client(managed_docker):
             "config",
             "yacron.yml"
         }
-        # assert string_from_volume(vol, "name") == "bob"
-        # assert check(cfg, "bob").key_volume == vol
-        # msg = "Configuration is for 'bob', not 'alice'"
-        # cfg.servers[0].key_volume = vol
-        # with pytest.raises(Exception, match=msg):
-        #     check(cfg, "alice")
+        schedule = string_from_volume(vol, "yacron.yml")
+        expected = generate_yacron_yaml(cfg, "bob")
+        assert schedule == "".join([x + "\n" for x in expected])

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -91,7 +91,7 @@ def test_can_write_schedule_for_client(managed_docker):
             "id_rsa.pub",
             "name",
             "config",
-            "yacron.yml"
+            "yacron.yml",
         }
         schedule = string_from_volume(vol, "yacron.yml")
         expected = generate_yacron_yaml(cfg, "bob")

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -26,10 +26,10 @@ def test_can_print_instructions_to_run_restore(capsys, managed_docker):
         assert "Command to manually run restore:" in lines
         cmd = (
             "  docker run --rm "
-            f"-v {vol}:/privateer/keys:ro -v data:/privateer/data "
+            f"-v {vol}:/privateer/keys:ro -v data:/privateer/volumes/data "
             f"mrcide/privateer-client:{cfg.tag} "
             "rsync -av --delete alice:/privateer/volumes/bob/data/ "
-            "/privateer/data/"
+            "/privateer/volumes/data/"
         )
         assert cmd in lines
 
@@ -54,14 +54,14 @@ def test_can_run_restore(monkeypatch, managed_docker):
             "-av",
             "--delete",
             "alice:/privateer/volumes/bob/data/",
-            "/privateer/data/",
+            "/privateer/volumes/data/",
         ]
         mounts = [
             docker.types.Mount(
                 "/privateer/keys", vol, type="volume", read_only=True
             ),
             docker.types.Mount(
-                "/privateer/data", "data", type="volume", read_only=False
+                "/privateer/volumes/data", "data", type="volume", read_only=False
             ),
         ]
         assert mock_run.call_count == 1
@@ -85,10 +85,10 @@ def test_restore_from_local_volume(capsys, managed_docker):
         assert "Command to manually run restore:" in lines
         cmd = (
             "  docker run --rm "
-            f"-v {vol}:/privateer/keys:ro -v other:/privateer/other "
+            f"-v {vol}:/privateer/keys:ro -v other:/privateer/volumes/other "
             f"mrcide/privateer-client:{cfg.tag} "
             "rsync -av --delete alice:/privateer/local/other/ "
-            "/privateer/other/"
+            "/privateer/volumes/other/"
         )
         assert cmd in lines
 
@@ -113,10 +113,10 @@ def test_restore_from_alternative_source(capsys, managed_docker):
         assert "Command to manually run restore:" in lines
         cmd = (
             "  docker run --rm "
-            f"-v {vol_dan}:/privateer/keys:ro -v data:/privateer/data "
+            f"-v {vol_dan}:/privateer/keys:ro -v data:/privateer/volumes/data "
             f"mrcide/privateer-client:{cfg.tag} "
             "rsync -av --delete carol:/privateer/volumes/bob/data/ "
-            "/privateer/data/"
+            "/privateer/volumes/data/"
         )
         assert cmd in lines
 
@@ -127,9 +127,9 @@ def test_restore_from_alternative_source(capsys, managed_docker):
         assert "Command to manually run restore:" in lines
         cmd = (
             "  docker run --rm "
-            f"-v {vol_dan}:/privateer/keys:ro -v other:/privateer/other "
-            f"mrcide/privateer-client:{cfg.tag} "
+            f"-v {vol_dan}:/privateer/keys:ro -v other:/privateer/volumes/other"
+            f" mrcide/privateer-client:{cfg.tag} "
             "rsync -av --delete carol:/privateer/local/other/ "
-            "/privateer/other/"
+            "/privateer/volumes/other/"
         )
         assert cmd in lines

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -61,7 +61,10 @@ def test_can_run_restore(monkeypatch, managed_docker):
                 "/privateer/keys", vol, type="volume", read_only=True
             ),
             docker.types.Mount(
-                "/privateer/volumes/data", "data", type="volume", read_only=False
+                "/privateer/volumes/data",
+                "data",
+                type="volume",
+                read_only=False,
             ),
         ]
         assert mock_run.call_count == 1
@@ -127,8 +130,9 @@ def test_restore_from_alternative_source(capsys, managed_docker):
         assert "Command to manually run restore:" in lines
         cmd = (
             "  docker run --rm "
-            f"-v {vol_dan}:/privateer/keys:ro -v other:/privateer/volumes/other"
-            f" mrcide/privateer-client:{cfg.tag} "
+            f"-v {vol_dan}:/privateer/keys:ro "
+            "-v other:/privateer/volumes/other "
+            f"mrcide/privateer-client:{cfg.tag} "
             "rsync -av --delete carol:/privateer/local/other/ "
             "/privateer/volumes/other/"
         )

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -5,7 +5,8 @@ import vault_dev
 
 import privateer2.schedule
 from privateer2.config import read_config
-from privateer2.keys import configure, keygen_all
+from privateer2.configure import configure
+from privateer2.keys import keygen_all
 from privateer2.schedule import schedule_start, schedule_status, schedule_stop
 
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -30,7 +30,7 @@ def test_can_print_instructions_to_start_schedule(capsys, managed_docker):
         schedule_start(cfg, "bob", dry_run=True)
         out = capsys.readouterr()
         lines = out.out.strip().split("\n")
-        assert "Command to manually launch server:" in lines
+        assert "Command to manually launch service container:" in lines
         cmd = (
             f"  docker run --rm -d --name {name} "
             f"-v {vol_keys}:/privateer/keys:ro "

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,112 @@
+from unittest.mock import MagicMock, call
+
+import vault_dev
+
+import privateer2.schedule
+from privateer2.config import read_config
+from privateer2.keys import configure, keygen_all
+from privateer2.schedule import schedule_start, schedule_status, schedule_stop
+
+
+def test_can_print_instructions_to_start_schedule(capsys, managed_docker):
+    with vault_dev.Server(export_token=True) as schedule:
+        cfg = read_config("example/schedule.json")
+        cfg.vault.url = schedule.url()
+        vol_keys = managed_docker("volume")
+        vol_data1 = managed_docker("volume")
+        vol_data2 = managed_docker("volume")
+        name = managed_docker("container")
+        cfg.clients[0].key_volume = vol_keys
+        cfg.clients[0].backup = [vol_data1, vol_data2]
+        cfg.clients[0].restore = [vol_data1, vol_data2]
+        cfg.clients[0].backup = [vol_data1, vol_data2]
+        cfg.clients[0].schedule.container = name
+        cfg.clients[0].schedule.jobs[0].volume = vol_data1
+        cfg.clients[0].schedule.jobs[1].volume = vol_data2
+        keygen_all(cfg)
+        configure(cfg, "bob")
+        capsys.readouterr()  # flush previous output
+        schedule_start(cfg, "bob", dry_run=True)
+        out = capsys.readouterr()
+        lines = out.out.strip().split("\n")
+        assert "Command to manually launch server:" in lines
+        cmd = (
+            f"  docker run --rm -d --name {name} "
+            f"-v {vol_keys}:/privateer/keys:ro "
+            f"-v {vol_data1}:/privateer/volumes/{vol_data1}:ro "
+            f"-v {vol_data2}:/privateer/volumes/{vol_data2}:ro "
+            f"-p 8080:8080 mrcide/privateer-client:{cfg.tag} "
+            "yacron -c /privateer/keys/yacron.yml"
+        )
+        assert cmd in lines
+
+
+def test_can_start_schedule(monkeypatch, managed_docker):
+    mock_docker = MagicMock()
+    mock_start = MagicMock()
+    monkeypatch.setattr(privateer2.schedule, "docker", mock_docker)
+    monkeypatch.setattr(privateer2.schedule, "service_start", mock_start)
+    with vault_dev.Server(export_token=True) as schedule:
+        cfg = read_config("example/schedule.json")
+        cfg.vault.url = schedule.url()
+        vol_keys = managed_docker("volume")
+        vol_data1 = managed_docker("volume")
+        vol_data2 = managed_docker("volume")
+        name = managed_docker("container")
+        cfg.clients[0].key_volume = vol_keys
+        cfg.clients[0].backup = [vol_data1, vol_data2]
+        cfg.clients[0].restore = [vol_data1, vol_data2]
+        cfg.clients[0].backup = [vol_data1, vol_data2]
+        cfg.clients[0].schedule.container = name
+        cfg.clients[0].schedule.jobs[0].volume = vol_data1
+        cfg.clients[0].schedule.jobs[1].volume = vol_data2
+        keygen_all(cfg)
+        configure(cfg, "bob")
+        schedule_start(cfg, "bob")
+        mount = mock_docker.types.Mount
+        assert mount.call_count == 3
+        assert mount.call_args_list[0] == call(
+            "/privateer/keys", vol_keys, type="volume", read_only=True
+        )
+        assert mount.call_args_list[1] == call(f"/privateer/volumes/{vol_data1}", vol_data1, type="volume", read_only=True)
+        assert mount.call_args_list[2] == call(
+            f"/privateer/volumes/{vol_data2}", vol_data2, type="volume", read_only=True
+        )
+        assert mock_start.call_count == 1
+        assert mock_start.call_args == call(
+            "bob",
+            name,
+            image=f"mrcide/privateer-client:{cfg.tag}",
+            mounts=[mount.return_value] * 3,
+            ports={"8080/tcp": 8080},
+            command=["yacron", "-c", "/privateer/keys/yacron.yml"],
+            dry_run=False,
+        )
+
+
+def test_can_stop_schedule(monkeypatch):
+    mock_check = MagicMock()
+    mock_stop = MagicMock()
+    cfg = MagicMock()
+    monkeypatch.setattr(privateer2.schedule, "check", mock_check)
+    monkeypatch.setattr(privateer2.schedule, "service_stop", mock_stop)
+    schedule_stop(cfg, "bob")
+    assert mock_check.call_count == 1
+    assert mock_check.call_args == call(cfg, "bob", quiet=True)
+    container = mock_check.return_value.schedule.container
+    assert mock_stop.call_count == 1
+    assert mock_stop.call_args == call("bob", container)
+
+
+def test_can_get_schedule_status(monkeypatch):
+    mock_check = MagicMock()
+    mock_status = MagicMock()
+    cfg = MagicMock()
+    monkeypatch.setattr(privateer2.schedule, "check", mock_check)
+    monkeypatch.setattr(privateer2.schedule, "service_status", mock_status)
+    schedule_status(cfg, "bob")
+    assert mock_check.call_count == 1
+    assert mock_check.call_args == call(cfg, "bob", quiet=False)
+    container = mock_check.return_value.schedule.container
+    assert mock_status.call_count == 1
+    assert mock_status.call_args == call(container)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -69,9 +69,17 @@ def test_can_start_schedule(monkeypatch, managed_docker):
         assert mount.call_args_list[0] == call(
             "/privateer/keys", vol_keys, type="volume", read_only=True
         )
-        assert mount.call_args_list[1] == call(f"/privateer/volumes/{vol_data1}", vol_data1, type="volume", read_only=True)
+        assert mount.call_args_list[1] == call(
+            f"/privateer/volumes/{vol_data1}",
+            vol_data1,
+            type="volume",
+            read_only=True,
+        )
         assert mount.call_args_list[2] == call(
-            f"/privateer/volumes/{vol_data2}", vol_data2, type="volume", read_only=True
+            f"/privateer/volumes/{vol_data2}",
+            vol_data2,
+            type="volume",
+            read_only=True,
         )
         assert mock_start.call_count == 1
         assert mock_start.call_args == call(
@@ -93,7 +101,7 @@ def test_cant_schedule_clients_with_no_schedule(managed_docker):
         cfg.clients[0].key_volume = vol
         keygen_all(cfg)
         configure(cfg, "bob")
-        msg = f"A schedule is not defined in the configuration for 'bob'"
+        msg = "A schedule is not defined in the configuration for 'bob'"
         with pytest.raises(Exception, match=msg):
             schedule_start(cfg, "bob", dry_run=True)
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -20,7 +20,6 @@ def test_can_print_instructions_to_start_schedule(capsys, managed_docker):
         name = managed_docker("container")
         cfg.clients[0].key_volume = vol_keys
         cfg.clients[0].backup = [vol_data1, vol_data2]
-        cfg.clients[0].restore = [vol_data1, vol_data2]
         cfg.clients[0].backup = [vol_data1, vol_data2]
         cfg.clients[0].schedule.container = name
         cfg.clients[0].schedule.jobs[0].volume = vol_data1
@@ -57,7 +56,6 @@ def test_can_start_schedule(monkeypatch, managed_docker):
         name = managed_docker("container")
         cfg.clients[0].key_volume = vol_keys
         cfg.clients[0].backup = [vol_data1, vol_data2]
-        cfg.clients[0].restore = [vol_data1, vol_data2]
         cfg.clients[0].backup = [vol_data1, vol_data2]
         cfg.clients[0].schedule.container = name
         cfg.clients[0].schedule.jobs[0].volume = vol_data1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,7 +25,7 @@ def test_can_print_instructions_to_start_server(capsys, managed_docker):
         server_start(cfg, "alice", dry_run=True)
         out = capsys.readouterr()
         lines = out.out.strip().split("\n")
-        assert "Command to manually launch server:" in lines
+        assert "Command to manually launch service container:" in lines
         cmd = (
             f"  docker run --rm -d --name {name} "
             f"-v {vol_keys}:/privateer/keys:ro "

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -187,3 +187,9 @@ def test_can_copy_string_into_volume(managed_docker):
     assert privateer2.util.string_from_volume(vol, "test") == "hello"
     privateer2.util.string_to_volume(["hello", "world"], vol, "test")
     assert privateer2.util.string_from_volume(vol, "test") == "hello\nworld\n"
+
+
+def test_can_uniquify_list():
+    assert privateer2.util.unique([]) == []
+    assert privateer2.util.unique([1, 2, 3]) == [1, 2, 3]
+    assert privateer2.util.unique([3, 2, 1, 2, 3]) == [3, 2, 1]

--- a/tests/test_yacron.py
+++ b/tests/test_yacron.py
@@ -1,0 +1,21 @@
+from privateer2.backup import backup_command
+from privateer2.config import read_config
+from privateer2.util import current_timezone_name
+from privateer2.yacron import generate_yacron_yaml, validate_yacron_yaml
+
+
+def test_can_generate_yacron_yaml():
+    cfg = read_config("example/schedule.json")
+    cfg.clients[0].schedule.port = None
+    cfg.clients[0].schedule.jobs.pop()
+    res = generate_yacron_yaml(cfg, "bob")
+    expected = [
+        "defaults:",
+        f'  timezone: "{current_timezone_name()}"',
+        "jobs:",
+        '  - name: "job-1"',
+        f"    command: \"{' '.join(backup_command('bob', 'data1', 'alice'))}\"",
+        '    schedule: "@daily"',
+    ]
+    validate_yacron_yaml(res)
+    assert res == expected

--- a/tests/test_yacron.py
+++ b/tests/test_yacron.py
@@ -3,7 +3,7 @@ import pytest
 from privateer2.backup import backup_command
 from privateer2.config import read_config
 from privateer2.util import current_timezone_name
-from privateer2.yacron import generate_yacron_yaml, _validate_yacron_yaml
+from privateer2.yacron import _validate_yacron_yaml, generate_yacron_yaml
 
 
 def test_can_generate_yacron_yaml():
@@ -43,10 +43,12 @@ def test_can_add_web_interface():
 
 
 def test_can_check_yacron_config_is_valid():
-    valid = ["jobs:",
-             "- name: name",
-             "  command: command",
-             "  schedule: '@daily'"]
+    valid = [
+        "jobs:",
+        "- name: name",
+        "  command: command",
+        "  schedule: '@daily'",
+    ]
     assert _validate_yacron_yaml(valid)
 
     # Missing a key

--- a/tests/test_yacron.py
+++ b/tests/test_yacron.py
@@ -1,7 +1,9 @@
+import pytest
+
 from privateer2.backup import backup_command
 from privateer2.config import read_config
 from privateer2.util import current_timezone_name
-from privateer2.yacron import generate_yacron_yaml, validate_yacron_yaml
+from privateer2.yacron import generate_yacron_yaml, _validate_yacron_yaml
 
 
 def test_can_generate_yacron_yaml():
@@ -17,5 +19,40 @@ def test_can_generate_yacron_yaml():
         f"    command: \"{' '.join(backup_command('bob', 'data1', 'alice'))}\"",
         '    schedule: "@daily"',
     ]
-    validate_yacron_yaml(res)
+    assert _validate_yacron_yaml(res)
     assert res == expected
+
+
+def test_can_add_web_interface():
+    cfg = read_config("example/schedule.json")
+    cfg.clients[0].schedule.jobs.pop()
+    res = generate_yacron_yaml(cfg, "bob")
+    expected = [
+        "defaults:",
+        f'  timezone: "{current_timezone_name()}"',
+        "web:",
+        "  listen:",
+        "    - http://0.0.0.0:8080",
+        "jobs:",
+        '  - name: "job-1"',
+        f"    command: \"{' '.join(backup_command('bob', 'data1', 'alice'))}\"",
+        '    schedule: "@daily"',
+    ]
+    assert _validate_yacron_yaml(res)
+    assert res == expected
+
+
+def test_can_check_yacron_config_is_valid():
+    valid = ["jobs:",
+             "- name: name",
+             "  command: command",
+             "  schedule: '@daily'"]
+    assert _validate_yacron_yaml(valid)
+
+    # Missing a key
+    with pytest.raises(Exception, match="command"):
+        _validate_yacron_yaml(valid[:-1])
+
+    # Syntax error:
+    with pytest.raises(Exception, match="mapping"):
+        _validate_yacron_yaml(valid[1:])

--- a/tests/test_yacron.py
+++ b/tests/test_yacron.py
@@ -23,9 +23,14 @@ def test_can_generate_yacron_yaml():
     assert res == expected
 
 
-def test_can_generate_empty_yacron_yaml():
+def test_can_generate_empty_yacron_yaml_for_server():
     cfg = read_config("example/simple.json")
     assert generate_yacron_yaml(cfg, "alice") is None
+
+
+def test_can_generate_empty_yacron_yaml_for_client_with_no_schedule():
+    cfg = read_config("example/simple.json")
+    assert generate_yacron_yaml(cfg, "bob") is None
 
 
 def test_can_add_web_interface():

--- a/tests/test_yacron.py
+++ b/tests/test_yacron.py
@@ -23,6 +23,11 @@ def test_can_generate_yacron_yaml():
     assert res == expected
 
 
+def test_can_generate_empty_yacron_yaml():
+    cfg = read_config("example/simple.json")
+    assert generate_yacron_yaml(cfg, "alice") is None
+
+
 def test_can_add_web_interface():
     cfg = read_config("example/schedule.json")
     cfg.clients[0].schedule.jobs.pop()


### PR DESCRIPTION
This PR adds a scheduler to run on the clients. I've not tried this out yet in anger, but will do so on Friday.

With this PR we can run a long-running process on production/production2 that will ship data to annex2, running daily.

Some things here:

* I've used the `timezone` argument to yacron to make the cron commands interpretable against the local time even when the container is running in utc (the default).
* we can expose the yacron web service out of the container, which will be nice for getting metrics out from backups, and better than doing something weird ourselves I think
* I've run the generated yaml through the yacron validator before writing it out, which makes up for the fact that I am not using a yaml emitter here but just writing it out by hand like a savage
* the scheduler has the same start/status/stop pair as the server - I took the liberty of a little light refactoring in c876866c456b3644fea81594c5773562629bb49a which I snuck in just before #1 was merged
* note also I did a really boring bit of code moving around in #3, so the keys.py module is a little less sprawling than before, and had to hotfix some bugs in #4 this morning as I got backup running from production and production2

Don't be afraid about the diff - this is 168 lines of code changed within `src/`, the rest is tests and config