### PR TITLE
Require that all server volume and container names are given

### DIFF
--- a/example/complex.json
+++ b/example/complex.json
@@ -3,12 +3,18 @@
         {
             "name": "alice",
             "hostname": "alice.example.com",
-            "port": 10022
+            "port": 10022,
+            "key_volume": "privateer_keys",
+            "data_volume": "privateer_data",
+            "container": "privateer_server"
         },
         {
             "name": "carol",
             "hostname": "alice.example.com",
-            "port": 10022
+            "port": 10022,
+            "key_volume": "privateer_keys",
+            "data_volume": "privateer_data",
+            "container": "privateer_server"
         }
     ],
     "clients": [

--- a/example/local.json
+++ b/example/local.json
@@ -5,7 +5,8 @@
             "hostname": "alice.example.com",
             "port": 10022,
             "key_volume": "privateer_keys_alice",
-            "data_volume": "privateer_data_alice"
+            "data_volume": "privateer_data_alice",
+            "container": "privateer_server"
         }
     ],
     "clients": [

--- a/example/montagu.json
+++ b/example/montagu.json
@@ -3,12 +3,18 @@
         {
             "name": "annex",
             "hostname": "annex.montagu.dide.ic.ac.uk",
-            "port": 10022
+            "port": 10022,
+            "key_volume": "privateer_montagu_keys",
+            "data_volume": "privateer_montagu_data",
+            "container": "privateer_montagu_server"
         },
         {
             "name": "annex2",
             "hostname": "annex2.montagu.dide.ic.ac.uk",
-            "port": 10022
+            "port": 10022,
+            "key_volume": "privateer_montagu_keys",
+            "data_volume": "privateer_montagu_data",
+            "container": "privateer_montagu_server"
         }
     ],
     "clients": [

--- a/example/schedule.json
+++ b/example/schedule.json
@@ -3,7 +3,10 @@
         {
             "name": "alice",
             "hostname": "alice.example.com",
-            "port": 10022
+            "port": 10022,
+            "key_volume": "privateer_keys",
+            "data_volume": "privateer_data",
+            "container": "privateer_server"
         }
     ],
     "clients": [

--- a/example/simple.json
+++ b/example/simple.json
@@ -3,7 +3,10 @@
         {
             "name": "alice",
             "hostname": "alice.example.com",
-            "port": 10022
+            "port": 10022,
+            "key_volume": "privateer_keys",
+            "data_volume": "privateer_data",
+            "container": "privateer_server"
         }
     ],
     "clients": [

--- a/src/privateer2/__about__.py
+++ b/src/privateer2/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Rich FitzJohn <r.fitzjohn@imperial.ac.uk>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/src/privateer2/config.py
+++ b/src/privateer2/config.py
@@ -28,9 +28,9 @@ class Server(BaseModel):
     name: str
     hostname: str
     port: int
-    key_volume: str = "privateer_keys"
-    data_volume: str = "privateer_data"
-    container: str = "privateer_server"
+    key_volume: str
+    data_volume: str
+    container: str
 
 
 class Client(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,7 +40,10 @@ def test_validation_is_run_on_load(tmp_path):
         {
             "name": "alice",
             "hostname": "alice.example.com",
-            "port": 10022
+            "port": 10022,
+            "key_volume": "privateer_keys",
+            "data_volume": "privateer_data",
+            "container": "privateer_server"
         }
     ],
     "clients": [


### PR DESCRIPTION
Following from the issue we spotted yesterday, now require that all server components are named.